### PR TITLE
Added phone input mask utility class

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,20 @@
+module.exports = function (config) {
+    config.set({
+        frameworks: ['systemjs', 'qunit'],
+        files: [
+        'dist/*.test.js',
+        { pattern: 'dist/**/*!(.test).js', included: false }
+        ],
+        plugins: ['karma-systemjs', 'karma-qunit', 'karma-chrome-launcher'],
+        systemjs: {
+        configFile: 'system.conf.js'
+        },
+        browsers: ['Chrome'],
+        browserNoActivityTimeout: 15000,
+        browserDisconnectTolerance: 10,
+        colors: true,
+        logLevel: config.LOG_INFO,
+        autoWatch: true,
+        concurrency: Infinity
+    });
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,20 +1,20 @@
 module.exports = function (config) {
-    config.set({
-        frameworks: ['systemjs', 'qunit'],
-        files: [
-        'dist/*.test.js',
-        { pattern: 'dist/**/*!(.test).js', included: false }
-        ],
-        plugins: ['karma-systemjs', 'karma-qunit', 'karma-chrome-launcher'],
-        systemjs: {
-        configFile: 'system.conf.js'
-        },
-        browsers: ['Chrome'],
-        browserNoActivityTimeout: 15000,
-        browserDisconnectTolerance: 10,
-        colors: true,
-        logLevel: config.LOG_INFO,
-        autoWatch: true,
-        concurrency: Infinity
-    });
+  config.set({
+    frameworks: ['systemjs', 'qunit'],
+    files: [
+      'dist/*.test.js',
+      { pattern: 'dist/**/*!(.test).js', included: false }
+    ],
+    plugins: ['karma-systemjs', 'karma-qunit', 'karma-chrome-launcher'],
+    systemjs: {
+    configFile: 'system.conf.js'
+    },
+    browsers: ['Chrome'],
+    browserNoActivityTimeout: 15000,
+    browserDisconnectTolerance: 10,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    concurrency: Infinity
+  });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-utilities",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Common utilites",
   "main": "src/js-utilities.ts",
   "scripts": {
@@ -31,7 +31,15 @@
   "format": "esm",
   "homepage": "https://github.com/GTMSportswear/js-utilities#readme",
   "devDependencies": {
+    "@types/qunit": "^2.0.31",
+    "karma": "^1.7.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-qunit": "^1.2.1",
+    "karma-systemjs": "^0.16.0",
+    "qunitjs": "^2.3.3",
+    "systemjs": "^0.19.40",
+    "traceur": "0.0.111",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.3"
+    "typescript": "^2.4.2"
   }
 }

--- a/src/input-mask.test.ts
+++ b/src/input-mask.test.ts
@@ -1,0 +1,75 @@
+import { InputMask } from './input-mask';
+
+let inputElement: HTMLInputElement;
+
+QUnit.module('InputMask', {
+  beforeEach: () => {
+    inputElement = document.createElement('input');
+  }
+});
+
+QUnit.test('Should mask empty telephone input on focus', assert => {
+  InputMask.TelephoneInputMask(inputElement);
+  inputElement.dispatchEvent(TestUtilities.FocusEvent);
+
+  assert.equal(inputElement.value, '(   )    -    ');
+});
+
+QUnit.test('Should remove telephone mask with empty input on blur', assert => {
+  InputMask.TelephoneInputMask(inputElement);
+  inputElement.dispatchEvent(TestUtilities.FocusEvent);
+  assert.equal(inputElement.value, '(   )    -    ');
+
+  inputElement.dispatchEvent(TestUtilities.BlurEvent);
+  assert.equal(inputElement.value, '');
+});
+
+QUnit.test('Should mask telephone input with entry for area code', assert => {
+  InputMask.TelephoneInputMask(inputElement);
+  inputElement.value = '12';
+  inputElement.dispatchEvent(TestUtilities.KeyupEvent);
+
+  assert.equal(inputElement.value, '(12 )    -    ');
+});
+
+QUnit.test('Should mask telephone input with entry for prefix', assert => {
+  InputMask.TelephoneInputMask(inputElement);
+  inputElement.value = '12345';
+  inputElement.dispatchEvent(TestUtilities.KeyupEvent);
+
+  assert.equal(inputElement.value, '(123) 45 -    ');
+});
+
+QUnit.test('Should mask telephone input with entry for line number', assert => {
+  InputMask.TelephoneInputMask(inputElement);
+  inputElement.value = '1234567';
+  inputElement.dispatchEvent(TestUtilities.KeyupEvent);
+
+  assert.equal(inputElement.value, '(123) 456-7   ');
+});
+
+QUnit.test('Should mask telephone input and strip letters from entry', assert => {
+  InputMask.TelephoneInputMask(inputElement);
+  inputElement.value = '1234s';
+  inputElement.dispatchEvent(TestUtilities.KeyupEvent);
+
+  assert.equal(inputElement.value, '(123) 4  -    ');
+});
+
+class TestUtilities {
+  public static FocusEvent = new Event('focus', {
+    bubbles: true,
+    cancelable: true
+  });
+
+  public static BlurEvent = new Event('blur', {
+    bubbles: true,
+    cancelable: true
+  });
+
+  public static KeyupEvent = new Event('keyup', {
+    bubbles: true,
+    cancelable: true
+  });
+}
+

--- a/src/input-mask.ts
+++ b/src/input-mask.ts
@@ -1,0 +1,126 @@
+export class InputMask {
+  public static TelephoneInputMask(inputElement: HTMLInputElement): void {
+    if (inputElement.tagName !== 'INPUT') return;
+
+    const digitRegex = /\d+/g;
+    const backspaceKeyCode = 8;
+    const deleteKeyCode = 46;
+    const leftArrowKeyCode = 37;
+    const rightArrowKeyCode = 39;
+
+    inputElement.addEventListener('keyup', (e: KeyboardEvent) => {
+      const input = <HTMLInputElement>e.target;
+      const inputValue = input.value;
+      const digits = inputValue.match(digitRegex);
+      let cursorStart = input.selectionStart;
+      let cursorEnd = input.selectionEnd;
+
+      if (digits === null) {
+        input.value = '';
+        input.value = this.TelephoneInputMaskFormat(input.value);
+        requestAnimationFrame(() => {
+          input.setSelectionRange(1, 1);
+        });
+        return;
+      }
+
+      if (e.keyCode === leftArrowKeyCode || e.keyCode === rightArrowKeyCode) return;
+
+      const digitsArray = digits.join('');
+
+      if (e.keyCode === backspaceKeyCode)
+        return requestAnimationFrame(() => {
+          input.setSelectionRange(input.selectionStart, input.selectionEnd);
+        });
+
+      if (digitsArray.length >= 10 && inputValue.length > 14)
+        return requestAnimationFrame(() => {
+          input.value = this.TelephoneInputMaskFormat(digitsArray);
+          input.setSelectionRange(input.selectionStart, input.selectionEnd);
+        });
+
+      if ((cursorStart === 5 || cursorStart === 8) && digitsArray.length > 10 && inputValue.length >= 14) {
+        cursorStart++;
+        cursorEnd++;
+      }
+
+      input.value = this.TelephoneInputMaskFormat(digitsArray);
+
+      if (digitsArray.length > 10)
+        return requestAnimationFrame(() => {
+          input.setSelectionRange(cursorStart, cursorEnd);
+        });
+
+      const cursorPositionIndex = this.GetRegexLastIndex(digitRegex, input.value, 1);
+
+      requestAnimationFrame(() => {
+        input.setSelectionRange(cursorPositionIndex, cursorPositionIndex);
+      });
+    });
+
+    inputElement.addEventListener('keydown', (e: KeyboardEvent) => {
+      const input = <HTMLInputElement>e.target;
+      const inputValue = input.value;
+      const digits = inputValue.match(digitRegex);
+
+      if (digits === null || e.keyCode === backspaceKeyCode || e.keyCode === deleteKeyCode) return;
+
+      const digitsArray = digits.join('');
+
+      if (digitsArray.length >= 10 && input.selectionStart > 12) {
+        e.preventDefault();
+        return false;
+      }
+    });
+
+    inputElement.addEventListener('focus', (e: Event) => {
+      const input = <HTMLInputElement>e.target;
+      const inputValue = input.value;
+      const digits = inputValue.match(digitRegex);
+
+      if (digits !== null) return;
+
+      input.value = this.TelephoneInputMaskFormat(inputValue);
+      requestAnimationFrame(() => {
+        input.setSelectionRange(1, 1);
+      });
+    });
+
+    inputElement.addEventListener('blur', (e: Event) => {
+      const input = <HTMLInputElement>e.target;
+      const inputValue = input.value;
+      const digits = inputValue.match(digitRegex);
+
+      if (digits === null)
+        input.value = '';
+    });
+  }
+
+  private static TelephoneInputMaskFormat(value: string): string {
+    const values = value.split('');
+    const emptyValues = Array(11).join(' ').split('');
+    const formattedValue = emptyValues.map((val: string, i) => {
+      if (values[i] !== undefined)
+        val = values[i];
+      if (i === 0)
+        val = '(' + val;
+      if (i === 3)
+        val = ') ' + val;
+      if (i === 6)
+        val = '-' + val;
+
+      return val;
+    }).join('');
+
+    return formattedValue;
+  }
+
+  private static GetRegexLastIndex(regex, value, returnValue): number {
+    if (regex.exec(value) !== null) {
+      returnValue = regex.lastIndex;
+      return this.GetRegexLastIndex(regex, value, returnValue);
+    }
+    else
+      return returnValue;
+  }
+}

--- a/system.conf.js
+++ b/system.conf.js
@@ -1,0 +1,10 @@
+System.config({
+  baseURL: "/",
+  defaultJSExtensions: true,
+  transpiler: "traceur",
+  paths: {
+    "systemjs": "node_modules/systemjs/dist/system.js",
+    "traceur": "node_modules/traceur/bin/traceur.js",
+    "github:*": "src/github/*"
+  }
+});


### PR DESCRIPTION
##Abstract
We want to be able to re-use the phone input mask utility that @someyoungideas developed for TeamStore. This pull request simply brings it over to the Github repo so that it can be re-shared. We plan to use it for a user story on Gtmsportswear.com for this sprint.

The only changes to Chris' original work:
- Added a space between the area code and the phone number, so `(785) 320-3283` as opposed to `(785)320-3283`
- Changed the default mask from `(___)___-____` to `(   )    -    ` (you'll have to imagine the correct number of spaces in there).